### PR TITLE
Adding Jenkins CI/CD for v2.7.3-AI4OS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,11 @@ pipeline {
                 script {
                     // Check if only metadata files have been changed
                     // See https://github.com/ai4os/ai4os-hub-qa/issues/16
-                    changed_files = sh (returnStdout: true, script: "git diff --name-only HEAD ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}").trim()
+                    if (env.GIT_PREVIOUS_SUCCESSFUL_COMMIT) {
+                        changed_files = sh (returnStdout: true, script: "git diff --name-only HEAD ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}").trim()
+                    } else {
+                        changed_files = sh (returnStdout: true, script: "git diff --name-only HEAD^ HEAD").trim()
+                    }
                     need_build = true
 
                     // Check if metadata files are present in the list of changed files

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
         THIS_REPO = "${env.GIT_URL.endsWith(".git") ? env.GIT_URL[0..-5] : env.GIT_URL}"
         DEFAULT_BRANCH = "v2.7.3-AI4OS"
         METADATA_VERSION = "2.0.0"
+        AI4OS_REGISTRY_CREDENTIALS = credentials('AIOS-registry-credentials')
     }
     stages {
         stage("Variable initialization") {
@@ -119,7 +120,7 @@ pipeline {
                     dockerfile = "Dockerfile"
                     docker_repo = env.DOCKER_REGISTRY_ORG + "/" + "ai4-cvat-server:" + env.IMAGE_TAG
                     docker_repo = docker_repo.toLowerCase()
-                    println ("[DEBUG] Config for the Docker image build: $env.DOCKER_REPO, push to $env.DOCKER_REGISTRY")
+                    println ("[DEBUG] Config for the Docker image build: ${docker_repo}, push to $env.DOCKER_REGISTRY")
                     docker.withRegistry(env.DOCKER_REGISTRY, env.DOCKER_REGISTRY_CREDENTIALS){
                          def app_image = docker.build(docker_repo,
                                                       "--no-cache --force-rm -f ${dockerfile} .")
@@ -153,7 +154,7 @@ pipeline {
                     dockerfile = "Dockerfile.ui"
                     docker_repo = env.DOCKER_REGISTRY_ORG + "/" + "ai4-cvat-ui:" + env.IMAGE_TAG
                     docker_repo = docker_repo.toLowerCase()
-                    println ("[DEBUG] Config for the Docker image build: $env.DOCKER_REPO, push to $env.DOCKER_REGISTRY")
+                    println ("[DEBUG] Config for the Docker image build: ${docker_repo}, push to $env.DOCKER_REGISTRY")
                     docker.withRegistry(env.DOCKER_REGISTRY, env.DOCKER_REGISTRY_CREDENTIALS){
                          def app_image = docker.build(docker_repo,
                                                       "--no-cache --force-rm -f ${dockerfile} .")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,172 @@
+#!/usr/bin/groovy
+
+// function to remove built images
+def docker_clean() {
+    def dangling_images = sh(
+		returnStdout: true,
+		script: "docker images -f 'dangling=true' -q"
+	)
+    if (dangling_images) {
+        sh(script: "docker rmi --force $dangling_images")
+    }
+}
+
+
+pipeline {
+    agent {
+        label 'docker'
+    }
+    environment {
+        // Remove .git from the GIT_URL link
+        THIS_REPO = "${env.GIT_URL.endsWith(".git") ? env.GIT_URL[0..-5] : env.GIT_URL}"
+        DEFAULT_BRANCH = "v2.7.3-AI4OS"
+        METADATA_VERSION = "2.0.0"
+    }
+    stages {
+        stage("Variable initialization") {
+            steps {
+                script {
+                    checkout scm
+                    withFolderProperties{
+                        env.DOCKER_REGISTRY = env.AI4OS_REGISTRY
+                        env.DOCKER_REGISTRY_ORG = env.AI4OS_REGISTRY_REPOSITORY
+                        env.DOCKER_REGISTRY_CREDENTIALS = env.AI4OS_REGISTRY_CREDENTIALS
+                    }
+                    // define tag based on branch
+                    env.IMAGE_TAG = "${env.BRANCH_NAME == 'main' ? 'latest' : env.BRANCH_NAME}"
+                }
+            }
+        }
+
+        stage('AI4OS Hub metadata V2 validation (YAML)') {
+            when {
+                // Check if ai4-metadata.yml is present in the repository
+                expression {fileExists("ai4-metadata.yml")}
+            }
+            agent {
+                docker {
+                    image 'ai4oshub/ci-images:python3.12'
+                }
+            }
+            steps {
+                script {
+                    if (!fileExists("ai4-metadata.yml")) {
+                        error("ai4-metadata.yml file not found in the repository")
+                    }
+                    if (fileExists("ai4-metadata.json")) {
+                        error("Both ai4-metadata.json and ai4-metadata.yml files found in the repository")
+                    }
+                }
+                script {
+                    sh "ai4-metadata validate --metadata-version ${env.METADATA_VERSION} ai4-metadata.yml"
+                }
+            }
+        }
+        stage("License validation") {
+            steps {
+                script {
+                    // Check if LICENSE file is present in the repository
+                    if (!fileExists("LICENSE")) {
+                        error("LICENSE file not found in the repository")
+                    }
+                }
+            }
+        }
+
+        stage("Check if only metadata files have changed") {
+            steps {
+                script {
+                    // Check if only metadata files have been changed
+                    // See https://github.com/ai4os/ai4os-hub-qa/issues/16
+                    changed_files = sh (returnStdout: true, script: "git diff --name-only HEAD ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}").trim()
+                    need_build = true
+
+                    // Check if metadata files are present in the list of changed files
+                    if (changed_files.contains("ai4-metadata.yml")) {
+                        // Convert to an array and pop items
+                        changed_files = changed_files.tokenize()
+                        changed_files.removeAll(["metadata.json", "ai4-metadata.json", "ai4-metadata.yml"])
+                        // now check if the list is empty
+                        if (changed_files.size() == 0) {
+                            need_build = false
+                        }
+                    }
+                }
+            }
+        }
+
+        stage("Docker build and push (Server)") {
+            when {
+                anyOf {
+                    branch 'main'
+                    branch env.DEFAULT_BRANCH
+                    branch 'release/*'
+                    buildingTag()
+                }
+                anyOf {
+                    expression {need_build}
+                    triggeredBy 'UserIdCause'
+                }
+            }
+            steps {
+                script {
+                    checkout scm
+                    dockerfile = "Dockerfile"
+                    docker_repo = env.DOCKER_REGISTRY_ORG + "/" + "ai4-cvat-server:" + env.IMAGE_TAG
+                    docker_repo = docker_repo.toLowerCase()
+                    println ("[DEBUG] Config for the Docker image build: $env.DOCKER_REPO, push to $env.DOCKER_REGISTRY")
+                    docker.withRegistry(env.DOCKER_REGISTRY, env.DOCKER_REGISTRY_CREDENTIALS){
+                         def app_image = docker.build(docker_repo,
+                                                      "--no-cache --force-rm -f ${dockerfile} .")
+                         app_image.push()
+                    }
+                }
+            }
+            post {
+                failure {
+                    docker_clean()
+                }
+            }
+        }
+
+        stage("Docker build and push (UI)") {
+            when {
+                anyOf {
+                    branch 'main'
+                    branch env.DEFAULT_BRANCH
+                    branch 'release/*'
+                    buildingTag()
+                }
+                anyOf {
+                    expression {need_build}
+                    triggeredBy 'UserIdCause'
+                }
+            }
+            steps {
+                script {
+                    checkout scm
+                    dockerfile = "Dockerfile.ui"
+                    docker_repo = env.DOCKER_REGISTRY_ORG + "/" + "ai4-cvat-ui:" + env.IMAGE_TAG
+                    docker_repo = docker_repo.toLowerCase()
+                    println ("[DEBUG] Config for the Docker image build: $env.DOCKER_REPO, push to $env.DOCKER_REGISTRY")
+                    docker.withRegistry(env.DOCKER_REGISTRY, env.DOCKER_REGISTRY_CREDENTIALS){
+                         def app_image = docker.build(docker_repo,
+                                                      "--no-cache --force-rm -f ${dockerfile} .")
+                         app_image.push()
+                    }
+                }
+            }
+            post {
+                failure {
+                    docker_clean()
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            cleanWs()
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,6 @@ pipeline {
                 anyOf {
                     branch 'main'
                     branch env.DEFAULT_BRANCH
-                    branch "${env.DEFAULT_BRANCH}-cicd"
                     branch 'release/*'
                     buildingTag()
                 }
@@ -118,8 +117,7 @@ pipeline {
                 script {
                     checkout scm
                     dockerfile = "Dockerfile"
-                    docker_repo = env.DOCKER_REGISTRY_ORG + "/" + "ai4-cvat-server:" + env.IMAGE_TAG
-                    docker_repo = docker_repo.toLowerCase()
+                    docker_repo = (env.DOCKER_REGISTRY_ORG + "/" + "ai4-cvat-server:" + env.IMAGE_TAG).toLowerCase()
                     println ("[DEBUG] Config for the Docker image build: ${docker_repo}, push to $env.DOCKER_REGISTRY")
                     docker.withRegistry(env.DOCKER_REGISTRY, env.DOCKER_REGISTRY_CREDENTIALS){
                          def app_image = docker.build(docker_repo,
@@ -152,8 +150,7 @@ pipeline {
                 script {
                     checkout scm
                     dockerfile = "Dockerfile.ui"
-                    docker_repo = env.DOCKER_REGISTRY_ORG + "/" + "ai4-cvat-ui:" + env.IMAGE_TAG
-                    docker_repo = docker_repo.toLowerCase()
+                    docker_repo = (env.DOCKER_REGISTRY_ORG + "/" + "ai4-cvat-ui:" + env.IMAGE_TAG).toLowerCase()
                     println ("[DEBUG] Config for the Docker image build: ${docker_repo}, push to $env.DOCKER_REGISTRY")
                     docker.withRegistry(env.DOCKER_REGISTRY, env.DOCKER_REGISTRY_CREDENTIALS){
                          def app_image = docker.build(docker_repo,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,6 +104,7 @@ pipeline {
                 anyOf {
                     branch 'main'
                     branch env.DEFAULT_BRANCH
+                    branch "${env.DEFAULT_BRANCH}-cicd"
                     branch 'release/*'
                     buildingTag()
                 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 > # 📌 AI4OS fork
-> [![Build image](https://github.com/ai4os/ai4-cvat/actions/workflows/ai4os-docker.yml/badge.svg)](https://github.com/ai4os/ai4-cvat/actions/workflows/ai4os-docker.yml)
-
-[![Build Status](https://jenkins.services.ai4os.eu/buildStatus/icon?job=AI4OS%2Fai4os-cvat%2Fv2.7.3-AI4OS-cicd)](https://jenkins.services.ai4os.eu/job/ai4os/job/ai4os-cvat/job/v2.7.3-AI4OS-cicd/)
+> [![Build image](https://github.com/ai4os/ai4-cvat/actions/workflows/ai4os-docker.yml/badge.svg)](https://github.com/ai4os/ai4-cvat/actions/workflows/ai4os-docker.yml) [![Build Status](https://jenkins.services.ai4os.eu/buildStatus/icon?job=AI4OS%2Fai4os-cvat%2Fv2.7.3-AI4OS)](https://jenkins.services.ai4os.eu/job/ai4os/job/ai4os-cvat/job/v2.7.3-AI4OS/)
 >
 > This is a fork of [CVAT](https://github.com/cvat-ai/cvat) to make it work with the [AI4OS platform](https://docs.ai4eosc.eu/).
 >

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 > # 📌 AI4OS fork
 > [![Build image](https://github.com/ai4os/ai4-cvat/actions/workflows/ai4os-docker.yml/badge.svg)](https://github.com/ai4os/ai4-cvat/actions/workflows/ai4os-docker.yml)
+
+[![Build Status](https://jenkins.services.ai4os.eu/buildStatus/icon?job=AI4OS%2Fai4os-cvat%2Fv2.7.3-AI4OS-cicd)](https://jenkins.services.ai4os.eu/job/ai4os/job/ai4os-cvat/job/v2.7.3-AI4OS-cicd/)
 >
 > This is a fork of [CVAT](https://github.com/cvat-ai/cvat) to make it work with the [AI4OS platform](https://docs.ai4eosc.eu/).
 >


### PR DESCRIPTION
### Motivation and context
This PR adds Jenkins CI/CD for checking ai4-metadata.yml, LICENSE file, and builds ai4-cvat-server and ai4-cvat-ui
It also adds CI/CD badge in README.md

**Important**: since Docker images can now be built via Jenkins, we should disable [ai4os-docker.yml](https://github.com/ai4os/ai4os-cvat/blob/v2.7.3-AI4OS/.github/workflows/ai4os-docker.yml) github action

This PR should close #2 

### How has this been tested?
Jenkins pipeline for this branch: 
https://jenkins.services.ai4os.eu/job/ai4os/job/ai4os-cvat/job/v2.7.3-AI4OS-cicd/

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
